### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "",
   "version": 1,
   "manifest_version": 1,
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "1",
   "permissions": ["tabs"],
   "action": {
     "default_icon": "icon/recording.png"


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)